### PR TITLE
Implement get player service

### DIFF
--- a/internal/ports/player.go
+++ b/internal/ports/player.go
@@ -4,7 +4,7 @@ import "github.com/jairogloz/go-l/internal/domain"
 
 type PlayerService interface {
 	Create(player *domain.Player) (err error)
-	Get(id domain.Player) (player domain.Player, err error)
+	Get(id string) (player domain.Player, err error)
 	Delete(id domain.Player) (err error)
 }
 

--- a/internal/services/player/get.go
+++ b/internal/services/player/get.go
@@ -1,8 +1,27 @@
 package player
 
-import "github.com/jairogloz/go-l/internal/domain"
+import (
+	"fmt"
+	"log"
 
-func (s *Service) Get(id domain.Player) (player domain.Player, err error) {
-	//TODO implement me
-	panic("implement me")
+	"github.com/jairogloz/go-l/internal/domain"
+)
+
+type GetPlayerError struct {
+	details error
+}
+
+func (e GetPlayerError) Error() string {
+	return fmt.Sprintf("error getting player: %s", e.details.Error())
+}
+
+func (s *Service) Get(id string) (player domain.Player, err error) {
+	player, err = s.Repo.Get(id)
+	if err != nil {
+		log.Println(err.Error())
+		err = GetPlayerError{err}
+		return
+	}
+
+	return
 }


### PR DESCRIPTION
# Descripción

- Se implementa el servicio de Get de Players.
- Se cambia la firma del método Get del servicio de Player para recibir un id string en lugar de domain.Player.

# Tests

![image](https://github.com/jairogloz/go-l/assets/54339832/2048685a-2999-4bb4-bbcb-53a8e05a99ca)

close #5
