### PR TITLE
Agregar Makefile y .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# DATABASE
+MONGO_URI=mongodb+srv://<user>:<password>@<host:port>/

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+/build
 
 # Test binary, built with `go test -c`
 *.test
@@ -37,3 +38,7 @@
 
 # Ignore .env file
 .env
+
+# Ignore coverage files
+coverage.out
+coverage.html

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+.PHONY: build run test coverage clean fmt deps
+
+# Variables
+APP_NAME := goleagues
+MAIN_PACKAGE := ./cmd/api/main.go
+BUILD_DIR := ./build
+TEST_COVERAGE_OUT := coverage.out
+COVERAGE_HTML := coverage.html
+EXT :=
+
+# Detect OS
+ifeq ($(OS),Windows_NT)
+	EXT := .exe
+endif
+
+# Build the application
+build:
+	go build -o $(BUILD_DIR)/$(APP_NAME)$(EXT) $(MAIN_PACKAGE)
+
+# Run the application
+run:
+	go run $(MAIN_PACKAGE)
+
+# Run all tests with verbose output
+test:
+	go test -v ./...
+
+# Run tests with coverage and generate coverage report in HTML
+coverage:
+	go test -v -coverprofile=$(TEST_COVERAGE_OUT) ./...
+	go tool cover -html=$(TEST_COVERAGE_OUT) -o $(COVERAGE_HTML)
+
+# Clean up binaries and coverage files
+clean:
+	go clean
+	rm -r $(BUILD_DIR)
+	rm -f $(TEST_COVERAGE_OUT) $(COVERAGE_HTML)
+
+# Format the code
+fmt:
+	go fmt ./...
+
+# Install dependencies
+deps:
+	go mod tidy
+	go mod download


### PR DESCRIPTION
# Descripción

- Se agregó un makefile para facilitar el lanzar ciertos comandos como el go run, go build, y algunos para los tests y coverage para mas adelante.
- Se agregó un .env.example para colocar las variables de entorno a manera de plantilla para nuevas personas que vayan ingresando al proyecto.
 - Se actualizó el .git.ignore para ignorar archivos que se generen desde el makefile