### PR TITLE
Feature/add delete player handler

### DIFF
--- a/cmd/api/handlers/player/delete.go
+++ b/cmd/api/handlers/player/delete.go
@@ -1,0 +1,31 @@
+package player
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/jairogloz/go-l/cmd/api/core"
+)
+
+// DeletePlayer godoc
+// @Summary Delete a player
+// @Description Delete a player by ID
+// @Tags players
+// @Accept  json
+// @Produce  json
+// @Param id path string true "Player ID"
+// @Success 204 {object} map[string]interface{} "No content"
+// @Failure 400 {object} map[string]interface{} "error: string"
+// @Router /players/{id} [delete]
+func (h Handler) DeletePlayer(c *gin.Context) {
+	id := c.Param("id")
+
+	err := h.PlayerService.Delete(id)
+	if err != nil {
+		core.RespondError(c, err)
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -39,6 +39,7 @@ func main() {
 	}
 
 	ginEngine.POST("/players", playerHandler.CreatePlayer)
+	ginEngine.DELETE("/players/:id", playerHandler.DeletePlayer)
 
 	log.Fatalln(ginEngine.Run(":8001"))
 


### PR DESCRIPTION
# Descripción

- Se implementa el handler de delete player
  - En caso de error se maneja el error con la función `core.RespondError`
  - En caso de ir OK se responde sin contenido con un 204.
- Se agrega la ruta DELETE `/players/:id`

# Pruebas en postman

204:
![image](https://github.com/jairogloz/go-l/assets/54339832/986e98d5-d078-47d0-8385-1ad87c39b2d2)

404:
![image](https://github.com/jairogloz/go-l/assets/54339832/474d94ce-32f0-4abc-997d-4bf1725a088c)


close #12