### PR TITLE
Fixes #27: error con la función ManageError

### DIFF
--- a/internal/domain/app_error.go
+++ b/internal/domain/app_error.go
@@ -41,20 +41,20 @@ func (e AppError) Error() string {
 func ManageError(err error, msg string) error {
 	var appErr AppError
 
-	switch err {
-	case ErrDuplicateKey:
+	switch {
+	case errors.Is(err, ErrDuplicateKey):
 		log.Println("duplicate key")
 		appErr = AppError{
 			Code: ErrCodeDuplicateKey,
 			Msg:  "Duplicate key",
 		}
-	case ErrIncorrectID:
+	case errors.Is(err, ErrIncorrectID):
 		log.Println("incorrect id error")
 		appErr = AppError{
 			Code: ErrCodeInvalidParams,
 			Msg:  "Incorrect id",
 		}
-	case ErrNotFound:
+	case errors.Is(err, ErrNotFound):
 		log.Println("not found error")
 		appErr = AppError{
 			Code: ErrCodeNotFound,

--- a/internal/domain/app_error_test.go
+++ b/internal/domain/app_error_test.go
@@ -1,0 +1,97 @@
+package domain
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestManageError(t *testing.T) {
+	type args struct {
+		err error
+		msg string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr error
+	}{
+		{
+			name: "Test ManageError with ErrDuplicateKey error",
+			args: args{
+				err: ErrDuplicateKey,
+			},
+			wantErr: AppError{
+				Code: ErrCodeDuplicateKey,
+				Msg:  "Duplicate key",
+			},
+		},
+		{
+			name: "Test ManageError with wrap ErrDuplicateKey error",
+			args: args{
+				err: fmt.Errorf("wrap: %w", ErrDuplicateKey),
+			},
+			wantErr: AppError{
+				Code: ErrCodeDuplicateKey,
+				Msg:  "Duplicate key",
+			},
+		},
+		{
+			name: "Test ManageError with ErrIncorrectID error",
+			args: args{
+				err: ErrIncorrectID,
+			},
+			wantErr: AppError{
+				Code: ErrCodeInvalidParams,
+				Msg:  "Incorrect id",
+			},
+		},
+		{
+			name: "Test ManageError with wrap ErrIncorrectID error",
+			args: args{
+				err: fmt.Errorf("wrap: %w", ErrIncorrectID),
+			},
+			wantErr: AppError{
+				Code: ErrCodeInvalidParams,
+				Msg:  "Incorrect id",
+			},
+		},
+		{
+			name: "Test ManageError with ErrNotFound error",
+			args: args{
+				err: ErrNotFound,
+			},
+			wantErr: AppError{
+				Code: ErrCodeNotFound,
+				Msg:  "Not found",
+			},
+		},
+		{
+			name: "Test ManageError with wrap ErrNotFound error",
+			args: args{
+				err: fmt.Errorf("wrap: %w", ErrNotFound),
+			},
+			wantErr: AppError{
+				Code: ErrCodeNotFound,
+				Msg:  "Not found",
+			},
+		},
+		{
+			name: "Test ManageError with unknown error",
+			args: args{
+				err: errors.New("unknown error"),
+			},
+			wantErr: AppError{
+				Code: ErrCodeInternalServerError,
+				Msg:  "Server Error",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ManageError(tt.args.err, tt.args.msg); !errors.Is(err, tt.wantErr) {
+				t.Errorf("ManageError() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Cambios

- Se modifico la función ManageError para usar errors.Is
- Se añadieron pruebas unitarias para la función ManageError

# Pruebas
Decidí esta vez empezar a añadir ciertas pruebas al repo, esta vez empecé con las pruebas unitarias para solucionar este error
![image](https://github.com/jairogloz/go-l/assets/110353857/84974441-e2fe-4777-a579-78fab7e1aca6)
