### PR TITLE
Feature #46: Delete tournament flow

### DIFF
--- a/cmd/api/handlers/tournament/delete.go
+++ b/cmd/api/handlers/tournament/delete.go
@@ -17,6 +17,7 @@ import (
 // @Param id path string true "Tournament ID"
 // @Success 204 {object} map[string]interface{} "No content"
 // @Failure 400 {object} map[string]interface{} "error: string"
+// @Failure 404 {object} map[string]interface{} "error: string"
 // @Router /tournaments/{id} [delete]
 func (h Handler) DeleteTournament(c *gin.Context) {
 	id := c.Param("id")

--- a/cmd/api/handlers/tournament/delete.go
+++ b/cmd/api/handlers/tournament/delete.go
@@ -1,0 +1,31 @@
+package tournament
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/jairogloz/go-l/cmd/api/core"
+)
+
+// DeleteTournament godoc
+// @Summary Delete a tournament
+// @Description Delete a tournament by ID
+// @Tags tournaments
+// @Accept  json
+// @Produce  json
+// @Param id path string true "Tournament ID"
+// @Success 204 {object} map[string]interface{} "No content"
+// @Failure 400 {object} map[string]interface{} "error: string"
+// @Router /tournaments/{id} [delete]
+func (h Handler) DeleteTournament(c *gin.Context) {
+	id := c.Param("id")
+
+	err := h.TournamentService.Delete(c, id)
+	if err != nil {
+		core.RespondError(c, err)
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}

--- a/cmd/api/handlers/tournament/delete.go
+++ b/cmd/api/handlers/tournament/delete.go
@@ -18,6 +18,7 @@ import (
 // @Success 204 {object} map[string]interface{} "No content"
 // @Failure 400 {object} map[string]interface{} "error: string"
 // @Failure 404 {object} map[string]interface{} "error: string"
+// @Failure 500 {object} map[string]interface{} "error: string"
 // @Router /tournaments/{id} [delete]
 func (h Handler) DeleteTournament(c *gin.Context) {
 	id := c.Param("id")

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -63,6 +63,7 @@ func main() {
 	ginEngine.DELETE("/players/:id", playerHandler.DeletePlayer)
 
 	ginEngine.POST("/tournaments", tournamentHandler.CreateTournament)
+	ginEngine.DELETE("/tournaments/:id", tournamentHandler.DeleteTournament)
 
 	log.Fatalln(ginEngine.Run(":8001"))
 

--- a/mocks/mock_tournament_repository.go
+++ b/mocks/mock_tournament_repository.go
@@ -40,6 +40,20 @@ func (m *MockTournamentRepository) EXPECT() *MockTournamentRepositoryMockRecorde
 	return m.recorder
 }
 
+// Delete mocks base method.
+func (m *MockTournamentRepository) Delete(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockTournamentRepositoryMockRecorder) Delete(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockTournamentRepository)(nil).Delete), arg0, arg1)
+}
+
 // Insert mocks base method.
 func (m *MockTournamentRepository) Insert(arg0 context.Context, arg1 *domain.Tournament) error {
 	m.ctrl.T.Helper()

--- a/pkg/ports/tournament.go
+++ b/pkg/ports/tournament.go
@@ -9,9 +9,11 @@ import (
 // TournamentService is the interface that have methods to interact with the tournament entity.
 type TournamentService interface {
 	Create(ctx context.Context, tournament *domain.Tournament) (err error)
+	Delete(ctx context.Context, id string) (err error)
 }
 
 // TournamentRepository is the interface that have methods to interact with the tournament entity in the database.
 type TournamentRepository interface {
 	Insert(ctx context.Context, tournament *domain.Tournament) (err error)
+	Delete(ctx context.Context, id string) (err error)
 }

--- a/pkg/repositories/mongo/tournament/delete.go
+++ b/pkg/repositories/mongo/tournament/delete.go
@@ -1,0 +1,30 @@
+package tournament
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+
+	"github.com/jairogloz/go-l/pkg/domain"
+)
+
+// Delete deletes a tournament by id from db
+func (r *Repository) Delete(ctx context.Context, id string) (err error) {
+	teamID, err := primitive.ObjectIDFromHex(id)
+	if err != nil {
+		return domain.ErrIncorrectID
+	}
+
+	deleteResult, err := r.Collection.DeleteOne(ctx, bson.M{"_id": teamID})
+	if err != nil {
+		return fmt.Errorf("error deleting tournament: %s", err.Error())
+	}
+
+	if deleteResult.DeletedCount == 0 {
+		return domain.ErrNotFound
+	}
+
+	return nil
+}

--- a/pkg/repositories/mongo/tournament/delete.go
+++ b/pkg/repositories/mongo/tournament/delete.go
@@ -12,12 +12,12 @@ import (
 
 // Delete deletes a tournament by id from db
 func (r *Repository) Delete(ctx context.Context, id string) (err error) {
-	teamID, err := primitive.ObjectIDFromHex(id)
+	oid, err := primitive.ObjectIDFromHex(id)
 	if err != nil {
 		return domain.ErrIncorrectID
 	}
 
-	deleteResult, err := r.Collection.DeleteOne(ctx, bson.M{"_id": teamID})
+	deleteResult, err := r.Collection.DeleteOne(ctx, bson.M{"_id": oid})
 	if err != nil {
 		return fmt.Errorf("error deleting tournament: %s", err.Error())
 	}

--- a/pkg/services/tournament/delete.go
+++ b/pkg/services/tournament/delete.go
@@ -1,0 +1,39 @@
+package tournament
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/jairogloz/go-l/pkg/domain"
+)
+
+// Delete deletes a tournament by id.
+func (s *Service) Delete(ctx context.Context, id string) (err error) {
+	err = s.Repo.Delete(ctx, id)
+	if err != nil {
+		if errors.Is(err, domain.ErrIncorrectID) {
+			log.Println("Incorrect ID error")
+			appErr := domain.AppError{
+				Code: domain.ErrCodeInvalidParams,
+				Msg:  "error deleting tournament: incorrect ID",
+			}
+			return appErr
+		}
+
+		if errors.Is(err, domain.ErrNotFound) {
+			log.Println("Not found error")
+			appErr := domain.AppError{
+				Code: domain.ErrCodeNotFound,
+				Msg:  "error deleting tournament: not found",
+			}
+			return appErr
+		}
+
+		log.Println(err.Error())
+		return fmt.Errorf("error creating tournament: %w", err)
+	}
+
+	return
+}

--- a/pkg/services/tournament/delete.go
+++ b/pkg/services/tournament/delete.go
@@ -32,7 +32,7 @@ func (s *Service) Delete(ctx context.Context, id string) (err error) {
 		}
 
 		log.Println(err.Error())
-		return fmt.Errorf("error creating tournament: %w", err)
+		return fmt.Errorf("error deleting tournament: %w", err)
 	}
 
 	return

--- a/pkg/services/tournament/delete_test.go
+++ b/pkg/services/tournament/delete_test.go
@@ -1,0 +1,101 @@
+package tournament_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/jairogloz/go-l/mocks"
+	"github.com/jairogloz/go-l/pkg/domain"
+	"github.com/jairogloz/go-l/pkg/services/tournament"
+)
+
+func TestService_Delete(t *testing.T) {
+	ctx := context.TODO()
+
+	testTable := map[string]struct {
+		setup         func(mockRepo *mocks.MockTournamentRepository)
+		ctx           context.Context
+		id            string
+		assertionFunc func(subTest *testing.T, err error)
+	}{
+		"success": {
+			setup: func(mockRepo *mocks.MockTournamentRepository) {
+				mockRepo.EXPECT().Delete(ctx, "667a09ac8c8a44e9c44ec248").
+					Return(nil)
+			},
+			ctx: ctx,
+			id:  "667a09ac8c8a44e9c44ec248",
+			assertionFunc: func(subTest *testing.T, err error) {
+				assert.Nil(subTest, err)
+			},
+		},
+		"error incorrect id": {
+			setup: func(mockRepo *mocks.MockTournamentRepository) {
+				mockRepo.EXPECT().Delete(ctx, "incorrect-id").
+					Return(domain.ErrIncorrectID)
+			},
+			ctx: ctx,
+			id:  "incorrect-id",
+			assertionFunc: func(subTest *testing.T, err error) {
+				assert.NotNil(subTest, err)
+
+				var appErr domain.AppError
+				if errors.As(err, &appErr) {
+					assert.Equal(subTest, domain.ErrCodeInvalidParams, appErr.Code)
+					assert.Equal(subTest, "error deleting tournament: incorrect ID", appErr.Msg)
+				} else {
+					subTest.Errorf("expected AppError, got %v", err)
+				}
+			},
+		},
+		"error not found": {
+			setup: func(mockRepo *mocks.MockTournamentRepository) {
+				mockRepo.EXPECT().Delete(ctx, "667a09ac8c8a44e9c44ec248").
+					Return(domain.ErrNotFound)
+			},
+			ctx: ctx,
+			id:  "667a09ac8c8a44e9c44ec248",
+			assertionFunc: func(subTest *testing.T, err error) {
+				assert.NotNil(subTest, err)
+
+				var appErr domain.AppError
+				if errors.As(err, &appErr) {
+					assert.Equal(subTest, domain.ErrCodeNotFound, appErr.Code)
+					assert.Equal(subTest, "error deleting tournament: not found", appErr.Msg)
+				} else {
+					subTest.Errorf("expected AppError, got %v", err)
+				}
+			},
+		},
+		"generic error in repository": {
+			setup: func(mockRepo *mocks.MockTournamentRepository) {
+				mockRepo.EXPECT().Delete(ctx, "667a09ac8c8a44e9c44ec248").
+					Return(errors.New("unexpected error deleting tournament"))
+			},
+			ctx: ctx,
+			id:  "667a09ac8c8a44e9c44ec248",
+			assertionFunc: func(subTest *testing.T, err error) {
+				assert.NotNil(subTest, err)
+				assert.Contains(subTest, err.Error(), "unexpected error deleting tournament")
+			},
+		},
+	}
+
+	for name, tc := range testTable {
+		t.Run(name, func(subTest *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockRepo := mocks.NewMockTournamentRepository(ctrl)
+			tc.setup(mockRepo)
+
+			s := tournament.Service{Repo: mockRepo}
+			err := s.Delete(tc.ctx, tc.id)
+			tc.assertionFunc(subTest, err)
+		})
+	}
+}


### PR DESCRIPTION
# Descripción

- Se agrega método Delete para tournament repository
- Se  agrega método Delete para tournament service
- Se agrega handler para delete tournament
- Se actualiza el mock de tournament repository

# Pruebas

## Unitarias

Service: Coverage 100%
![image](https://github.com/jairogloz/go-l/assets/54339832/29aca40a-083f-407e-80bf-d27bae037ae8)

## End-to-end

204:
![image](https://github.com/jairogloz/go-l/assets/54339832/f52a0e2d-1736-4bc1-a91b-dd346976bc75)

404:
![image](https://github.com/jairogloz/go-l/assets/54339832/f5040318-64f3-4854-9eec-146ddf0f94f9)

400:
![image](https://github.com/jairogloz/go-l/assets/54339832/02d11014-19f8-4122-b663-33fd786c3b19)

500:
![image](https://github.com/jairogloz/go-l/assets/54339832/00b33b7f-0fc4-421f-8047-1a98f3e97ff9)


close #46
