### PR TITLE
Feature #19: Delete team service

### DIFF
--- a/pkg/services/team/delete.go
+++ b/pkg/services/team/delete.go
@@ -1,8 +1,18 @@
 package team
 
-import "context"
+import (
+	"context"
+
+	"github.com/jairogloz/go-l/pkg/domain"
+)
 
 func (s Service) Delete(ctx context.Context, id string) (err error) {
-	//TODO implement me
-	panic("implement me")
+
+	err = s.Repo.Delete(ctx, id)
+
+	if err != nil {
+		return domain.ManageError(err, "unexpected error deleting team")
+	}
+
+	return nil
 }

--- a/pkg/services/team/delete.go
+++ b/pkg/services/team/delete.go
@@ -6,6 +6,8 @@ import (
 	"github.com/jairogloz/go-l/pkg/domain"
 )
 
+// Delete removes a team from the repository.
+// It returns an error if the team does not exist or if there is an unexpected error.
 func (s Service) Delete(ctx context.Context, id string) (err error) {
 
 	err = s.Repo.Delete(ctx, id)

--- a/pkg/services/team/delete_test.go
+++ b/pkg/services/team/delete_test.go
@@ -1,0 +1,97 @@
+package team_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jairogloz/go-l/mocks"
+	"github.com/jairogloz/go-l/pkg/domain"
+	"github.com/jairogloz/go-l/pkg/services/team"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestService_Delete(t *testing.T) {
+
+	testTable := map[string]struct {
+		setup         func(mockRepo *mocks.MockTeamRepository)
+		teamId        string
+		assertionFunc func(subTest *testing.T, err error)
+	}{
+		"empty id": {
+			setup: func(mockRepo *mocks.MockTeamRepository) {
+				mockRepo.EXPECT().Delete(context.TODO(), "").Return(domain.ErrIncorrectID)
+			},
+			teamId: "",
+			assertionFunc: func(subTest *testing.T, err error) {
+				assert.NotNil(subTest, err)
+				var appErr domain.AppError
+				if errors.As(err, &appErr) {
+					assert.Equal(subTest, domain.ErrCodeInvalidParams, appErr.Code)
+					assert.Equal(subTest, "Incorrect id: unexpected error deleting team", appErr.Msg)
+				} else {
+					subTest.Errorf("expected AppError, got %v", err)
+				}
+			},
+		},
+		"delete not found error": {
+			setup: func(mockRepo *mocks.MockTeamRepository) {
+				mockRepo.EXPECT().Delete(context.TODO(), "abc").Return(domain.ErrNotFound)
+			},
+			teamId: "abc",
+			assertionFunc: func(subTest *testing.T, err error) {
+				assert.NotNil(subTest, err)
+				var appErr domain.AppError
+				if errors.As(err, &appErr) {
+					assert.Equal(subTest, domain.ErrCodeNotFound, appErr.Code)
+					assert.Equal(subTest, "Not found: unexpected error deleting team", appErr.Msg)
+				} else {
+					subTest.Errorf("expected AppError, got %v", err)
+				}
+			},
+		},
+
+		"team generic error": {
+			setup: func(mockRepo *mocks.MockTeamRepository) {
+				mockRepo.EXPECT().Delete(context.TODO(), "abc").Return(errors.New("generic error"))
+			},
+			teamId: "abc",
+			assertionFunc: func(subTest *testing.T, err error) {
+				assert.NotNil(subTest, err)
+			},
+		},
+
+		"succes": {
+			setup: func(mockRepo *mocks.MockTeamRepository) {
+				mockRepo.EXPECT().Delete(context.TODO(), "abc").Return(nil)
+			},
+			teamId: "abc",
+			assertionFunc: func(subTest *testing.T, err error) {
+				assert.Nil(subTest, err)
+			},
+		},
+	}
+
+	for testName, test := range testTable {
+		t.Run(testName, func(subTest *testing.T) {
+
+			ctrl := gomock.NewController(subTest)
+			defer ctrl.Finish()
+
+			mockTeamRepo := mocks.NewMockTeamRepository(ctrl)
+
+			s := &team.Service{
+				Repo: mockTeamRepo,
+			}
+
+			test.setup(mockTeamRepo)
+
+			err := s.Delete(context.TODO(), test.teamId)
+
+			test.assertionFunc(subTest, err)
+
+		})
+	}
+
+}


### PR DESCRIPTION
# Cambios
- Se agrego la lógica para delete team service
- Se creo los test para delete team service

# Pruebas
Se cumplió con un 100% de coverange en la función
![image](https://github.com/user-attachments/assets/2cf905f6-4fbd-43ff-aab0-eebe6b51e3e7)
![image](https://github.com/user-attachments/assets/cd36f93b-b204-4a83-bc60-f688e99d085c)
